### PR TITLE
feat: `--destdir` for package installations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,10 @@ version = 3
 [[package]]
 name = "cli_parser"
 version = "0.1.0"
+dependencies = [
+ "common",
+ "logger",
+]
 
 [[package]]
 name = "common"

--- a/lpm/cli_parser/Cargo.toml
+++ b/lpm/cli_parser/Cargo.toml
@@ -3,6 +3,6 @@ name = "cli_parser"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+common = { path = "../common" }
+logger = { path = "../../libs/logger" }

--- a/lpm/cli_parser/src/install.rs
+++ b/lpm/cli_parser/src/install.rs
@@ -1,8 +1,11 @@
 use std::collections::HashSet;
 
-#[derive(Debug, Default, PartialEq)]
+use common::some_or_error;
+
+#[derive(Debug, PartialEq)]
 pub struct InstallArgs<'a> {
     pub packages: HashSet<&'a str>,
+    pub destdir: &'a str,
     pub from_local_package: bool,
     pub print_help: bool,
     // TODO:
@@ -11,12 +14,26 @@ pub struct InstallArgs<'a> {
     // workspace: Option<String>,
 }
 
+impl<'a> Default for InstallArgs<'a> {
+    fn default() -> Self {
+        InstallArgs {
+            packages: HashSet::default(),
+            destdir: "/",
+            from_local_package: false,
+            print_help: false,
+        }
+    }
+}
+
 impl<'a> InstallArgs<'a> {
     pub(crate) fn parse(iter: &mut dyn Iterator<Item = &'a String>) -> Self {
         let mut args = InstallArgs::default();
 
-        for arg in iter {
+        while let Some(arg) = iter.next() {
             match arg.as_str() {
+                "--destdir" | "-d" => {
+                    args.destdir = some_or_error!(iter.next(), "Value for '--destdir' is missing. Check 'lpm --install --help' for more information.");
+                }
                 "--local" | "-L" => {
                     args.from_local_package = true;
                 }
@@ -40,6 +57,7 @@ impl<'a> InstallArgs<'a> {
         "Usage: lpm --install [FLAGS] <List of package names or Path>/[OPTION]
 
 Options:
+    -d, --destdir         <Target path>                       Installs package to specified path, similar to GNU DESTDIR (https://www.gnu.org/prep/standards/html_node/DESTDIR.html).
     -h, --help                                                Print help
 
 Flags:

--- a/lpm/cli_parser/src/lib.rs
+++ b/lpm/cli_parser/src/lib.rs
@@ -78,6 +78,8 @@ For more specific help, go for `lpm [SUBCOMMAND] --help`
 
             Command::Version => panic!("This should never happen. Seems like a bug."),
         }
+
+        std::process::exit(0);
     }
 }
 

--- a/lpm/cli_parser/src/update.rs
+++ b/lpm/cli_parser/src/update.rs
@@ -40,10 +40,10 @@ Options:
     -p, --packages                                            Update all the installed packages
     -i, --index                                               Update repository index from remote
     -d, --db                                                  Update lpm database(by applying remote migrations)
+    -l, --local         <Path of *.lod file>                  Updates from local *.lod file
     -h, --help                                                Print help
 
 Flags:
-    -l, --local                                               Activate updates from local *.lod file
     -y, --yes                                                 Preaccept the confirmation prompts
 "
     }

--- a/lpm/common/src/lib.rs
+++ b/lpm/common/src/lib.rs
@@ -46,7 +46,7 @@ macro_rules! some_or_error {
     ($fn: expr, $log: expr, $($args: tt)+) => {
         match $fn {
             Some(val) => val,
-            None => { 
+            None => {
                 logger::error!("{}", format!($log, $($args)+));
                 std::process::exit(101);
             },

--- a/lpm/common/src/lib.rs
+++ b/lpm/common/src/lib.rs
@@ -46,13 +46,19 @@ macro_rules! some_or_error {
     ($fn: expr, $log: expr, $($args: tt)+) => {
         match $fn {
             Some(val) => val,
-            None => panic!("{}", format!($log, $($args)+)),
+            None => { 
+                logger::error!("{}", format!($log, $($args)+));
+                std::process::exit(101);
+            },
         }
     };
     ($fn: expr, $log: expr) => {
         match $fn {
             Some(val) => val,
-            None => panic!("{}", format!($log)),
+            None => {
+                logger::error!("{}", format!($log));
+                std::process::exit(101);
+            },
         }
 
     }

--- a/sdk/src/high_level.rs
+++ b/sdk/src/high_level.rs
@@ -26,6 +26,7 @@ extern "C" fn install_lod_file(pkg_path: *const std::os::raw::c_char) -> ResultC
         ctx,
         &InstallArgs {
             packages: HashSet::from([pkg_path]),
+            destdir: "/",
             from_local_package: true,
             print_help: false,
         },


### PR DESCRIPTION
e.g., usage: `lpm --install $package --destdir $target`

**Key challenges that needs to be solved:**

- Managing dependencies
- Managing package scripts
- Managing package data in the database

Resolves #71